### PR TITLE
Change light mode background to light blue (bg-blue-100)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -94,7 +94,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <meta name="theme-color" media="(prefers-color-scheme: light)" content="#fff" />
       <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#000" />
       <link rel="alternate" type="application/rss+xml" href={`${basePath}/feed.xml`} />
-      <body className="bg-white pl-[calc(100vw-100%)] text-black antialiased dark:bg-gray-950 dark:text-white">
+      <body className="bg-blue-100 pl-[calc(100vw-100%)] text-black antialiased dark:bg-gray-950 dark:text-white">
         <ThemeProviders>
           <Analytics analyticsConfig={siteMetadata.analytics as AnalyticsConfig} />
           <SectionContainer>


### PR DESCRIPTION
- Changes the light mode background from white to Tailwind's bg-blue-100 (light blue) for a softer, friendlier appearance.
- Dark mode background remains unchanged.

Please review and preview the changes!